### PR TITLE
remove overrides

### DIFF
--- a/android/src/main/java/com/ziggeo/ZiggeoPackage.java
+++ b/android/src/main/java/com/ziggeo/ZiggeoPackage.java
@@ -18,7 +18,6 @@ public class ZiggeoPackage implements ReactPackage {
 
     private static final String TAG = ZiggeoPackage.class.getSimpleName();
 
-    @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new ZiggeoRecorderModule(reactContext));
@@ -27,12 +26,10 @@ public class ZiggeoPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
 
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
I had trouble getting the SDK to run, Android Studio complained about overrides in a class that was not a subclass.
This patch solved it for me.